### PR TITLE
Adjust player paddle speed to 90% for game balance

### DIFF
--- a/main.js
+++ b/main.js
@@ -676,17 +676,18 @@ function updateAI() {
 // Update paddle positions based on input
 function updatePaddles() {
     // Player 1 Controls (Arrow Keys) - Blue Paddle
+    const player1Speed = paddleSpeed * 0.9; // 90% speed for player
     if (keys['ArrowUp'] && paddle1.position.z > -rinkHeight/2 + 1) {
-        paddle1.position.z -= paddleSpeed;
+        paddle1.position.z -= player1Speed;
     }
     if (keys['ArrowDown'] && paddle1.position.z < rinkHeight/2 - 1) {
-        paddle1.position.z += paddleSpeed;
+        paddle1.position.z += player1Speed;
     }
     if (keys['ArrowLeft'] && paddle1.position.x > -rinkWidth/2 + 1) {
-        paddle1.position.x -= paddleSpeed;
+        paddle1.position.x -= player1Speed;
     }
     if (keys['ArrowRight'] && paddle1.position.x < rinkWidth/2 - 1) {
-        paddle1.position.x += paddleSpeed;
+        paddle1.position.x += player1Speed;
     }
     
     // Player 2 Controls - either human (WASD) or AI


### PR DESCRIPTION
## Summary
Quick adjustment to player paddle speed for better game balance after testing the new level progression system.

## Changes
- Player 1 (blue team) paddle speed reduced from 100% to 90% of base speed
- This creates a better difficulty curve:
  - Level 1: Player at 90%, AI at 60% (player advantage)
  - Level 2: Player at 90%, AI at 80% (slight player advantage)
  - Level 3: Player at 90%, AI at 100% (AI advantage)

## Rationale
After playtesting, the 90% speed provides the right challenge level and makes the progression feel more rewarding.

🏒 Small but important balance tweak\!